### PR TITLE
#10 - AuditingFields 추출

### DIFF
--- a/fastcampus-project-board/src/main/java/org/example/projectboard/domain/Article.java
+++ b/fastcampus-project-board/src/main/java/org/example/projectboard/domain/Article.java
@@ -28,9 +28,9 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 
-@EntityListeners(AuditingEntityListener.class)
+
 @Entity
-public class Article {
+public class Article extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,10 +46,7 @@ public class Article {
     @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
     private final Set<ArticleComment> articleComments = new LinkedHashSet<>();
 
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; // 생성일시
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; // 생성일시
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt; // 수정일시
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; // 수정자
+
 
 
     protected Article() {

--- a/fastcampus-project-board/src/main/java/org/example/projectboard/domain/ArticleComment.java
+++ b/fastcampus-project-board/src/main/java/org/example/projectboard/domain/ArticleComment.java
@@ -19,11 +19,10 @@ import java.util.Objects;
         @Index(columnList = "content"),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")
-})
+}) // 인덱스는 데이터베이스에서 검색 성능을 향상시키기 위해 사용됩니다.
 
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class ArticleComment  {
+public class ArticleComment extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -33,10 +32,7 @@ public class ArticleComment  {
     @Setter @ManyToOne(optional = false) private Article article; //게시글 (id)
     @Setter @Column(nullable = false,length = 500) private String content; // 내용
 
-    @CreatedDate @Column(nullable = false) private LocalDateTime createdAt; // 생성일시
-    @CreatedBy @Column(nullable = false, length = 100) private String createdBy; // 생성일시
-    @LastModifiedDate @Column(nullable = false) private LocalDateTime modifiedAt; // 수정일시
-    @LastModifiedBy @Column(nullable = false, length = 100) private String modifiedBy; // 수정자
+
 
     protected ArticleComment() {
     }

--- a/fastcampus-project-board/src/main/java/org/example/projectboard/domain/AuditingFields.java
+++ b/fastcampus-project-board/src/main/java/org/example/projectboard/domain/AuditingFields.java
@@ -1,0 +1,40 @@
+package org.example.projectboard.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class AuditingFields {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false,updatable = false)
+    private LocalDateTime createdAt; // 생성일시
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false, length = 100)
+    private String createdBy; // 생성자
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt; // 수정일시
+
+    @LastModifiedBy
+    @Column(nullable = false, length = 100)
+    private String modifiedBy; // 수정자
+
+}


### PR DESCRIPTION
생성자,생성일시,수정자,수정일시는 반복적으로 엔티티 클래스에 들어가는 요소이고, 도메인과 직접 연관이 없는 요소이므로 추출이 가능하다.

`@Mappedsuperclass`이용하여 상속 방식으로 추출함.

그외 `@DateTimeFormat` 요소 추가.